### PR TITLE
Fix missing return in bodyContains and two minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ Please see [UPGRADING](UPGRADING.md) for what to do to switch over from `themsai
 
 ## Contributing
 
-Please see [CONTRIBUTING](.github/CONTRIBUTING.md) for details.
+Please see [CONTRIBUTING](CONTRIBUTING.md) for details.
 
 ## Security Vulnerabilities
 

--- a/src/SentMails/SentMail.php
+++ b/src/SentMails/SentMail.php
@@ -22,7 +22,7 @@ class SentMail
 
     public function bodyContains(string $expectedSubstring): bool
     {
-        Str::contains($this->body(), $expectedSubstring);
+        return Str::contains($this->body(), $expectedSubstring);
     }
 
     public function subject(): ?string

--- a/src/SentMails/SentMails.php
+++ b/src/SentMails/SentMails.php
@@ -63,7 +63,6 @@ class SentMails
     public function timesSent(Closure $findMail): int
     {
         $timesSent = 0;
-        ;
         foreach ($this->mails as $mail) {
             if ($findMail($mail)) {
                 $timesSent++;

--- a/tests/Feature/SentMailsTest.php
+++ b/tests/Feature/SentMailsTest.php
@@ -108,4 +108,12 @@ class SentMailsTest extends TestCase
             return $mail->hasTo('john@example.com');
         });
     }
+
+    /** @test */
+    public function it_can_assert_the_body_content_for_a_sent_mail()
+    {
+        SentMails::assertSent(function (SentMail $mail) {
+            return $mail->bodyContains('this is the html');
+        });
+    }
 }


### PR DESCRIPTION
Hey,

great plugin, thanks!

So I wanted to use the bodyContains function it is missing the return statement.
I added it and also added a small test for that.

Also there was a broken link in the README to the CONTRIBUTING guide.
And a unnecessary semicolon in src/SentMails/SentMails.php that I removed.

Best regards