### PR TITLE
Fix HTML preview for Laravel 9

### DIFF
--- a/src/PreviewMailTransport.php
+++ b/src/PreviewMailTransport.php
@@ -11,6 +11,7 @@ use Spatie\MailPreview\SentMails\SentMails;
 use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\Transport\AbstractTransport;
+use Symfony\Component\Mime\MessageConverter;
 
 class PreviewMailTransport extends AbstractTransport
 {
@@ -60,7 +61,7 @@ class PreviewMailTransport extends AbstractTransport
     {
         $messageInfo = $this->getMessageInfo($message);
 
-        return $messageInfo . $message->getOriginalMessage()->getBody()->bodyToString();
+        return $messageInfo . MessageConverter::toEmail($message->getOriginalMessage())->getHtmlBody();
     }
 
     protected function getEmlPreviewContent(SentMessage $message): string


### PR DESCRIPTION
Hi,

The HTML preview was broken in Laravel 9. We need to convert the `SentMessage` instance back to an `Email` instance so we can call the `getHtmlBody()` method. The body of `SentMessage` contains an encoded form of the e-mail.

This PR fixes this issue.