### PR TITLE
Run parent transport constructor

### DIFF
--- a/src/PreviewMailTransport.php
+++ b/src/PreviewMailTransport.php
@@ -23,6 +23,8 @@ class PreviewMailTransport extends AbstractTransport
 
     public function __construct(Filesystem $files, int $maximumLifeTimeInSeconds = 60)
     {
+        parent::__construct();
+
         $this->filesystem = $files;
 
         $this->maximumLifeTimeInSeconds = $maximumLifeTimeInSeconds;


### PR DESCRIPTION
Hi guys,

After a recent `composer update` I ran into this issue when using this package:

```
Typed property Symfony\Component\Mailer\Transport\AbstractTransport::$dispatcher must not be accessed before initialization
```

This property became typed in a recent `symfony/mailer` [release](https://github.com/symfony/mailer/compare/v6.0.8...v6.1.0#diff-ed2ad005042f68b72509b125c85e42422af14df763c6cace50785c341967da87L28). 

With this PR we run the parent constructor so the property will be initialized.