### PR TITLE
fix: make setTimeoutInSeconds works

### DIFF
--- a/resources/views/previewLinkPopup.blade.php
+++ b/resources/views/previewLinkPopup.blade.php
@@ -1,6 +1,7 @@
 <div id="MailPreviewDriverBox" style="
     position:absolute;
-    top:0;
+    top:10px;
+    right:10px;
     z-index:99999;
     background:#fff;
     border:solid 1px #ccc;
@@ -15,9 +16,19 @@
             <a style="text-decoration: underline" href="{{ $previewUrl }}&file_type=eml">Open mail in email client</a>
         </li>
     </ul>
+    <span onclick="closePopup()" id="close" style="
+           cursor: pointer;
+           font-size: smaller;
+           position: absolute;
+           top: 2px;
+           right: 6px;
+           font-family: monospace;">X</span>
 </div>
 <script type="text/javascript">
-    setTimeout(function () {
+    function closePopup() {
         document.body.removeChild(document.getElementById('MailPreviewDriverBox'));
-    }, $timeoutInSeconds * 1000);
+    }
+    @if($timeoutInSeconds)
+        setTimeout(closePopup(), {{ $timeoutInSeconds }} * 1000);
+    @endif
 </script>


### PR DESCRIPTION
In previous version, variable $timeoutInSeconds wasn't scaped by double braces, so blade puts it like a string.
Now, it is fixed, and as a plus, added a X button to close manually