### PR TITLE
Prevent closePopup from running immediately

### DIFF
--- a/resources/views/previewLinkPopup.blade.php
+++ b/resources/views/previewLinkPopup.blade.php
@@ -22,13 +22,16 @@
            position: absolute;
            top: 2px;
            right: 6px;
-           font-family: monospace;">X</span>
+           font-family: monospace;
+    ">
+        X
+    </span>
 </div>
 <script type="text/javascript">
     function closePopup() {
         document.body.removeChild(document.getElementById('MailPreviewDriverBox'));
     }
     @if($timeoutInSeconds)
-        setTimeout(closePopup(), {{ $timeoutInSeconds }} * 1000);
+        setTimeout(closePopup, {{ $timeoutInSeconds }} * 1000);
     @endif
 </script>


### PR DESCRIPTION
Since version `6.0.3` the popup is not shown if `$timeoutInSeconds` is set, this PR fixes that.