### PR TITLE
Allow to change default filename date format

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,13 @@ return [
      * Set this to `false` if the popup should stay visible.
      */
     'popup_timeout_in_seconds' => 8,
+    
+    /**
+     * Determines the date format used for the file names.
+     *
+     * The default 'u' stands for microseconds.
+     */
+    'filename_date_format' => 'u',
 ];
 
 ```

--- a/config/mail-preview.php
+++ b/config/mail-preview.php
@@ -29,4 +29,11 @@ return [
      * Set this to `false` if the popup should stay visible.
      */
     'popup_timeout_in_seconds' => 8,
+
+    /**
+     * Determines the date format used for the file names.
+     *
+     * The default 'u' stands for microseconds.
+     */
+    'filename_date_format' => 'u',
 ];

--- a/src/PreviewMailTransport.php
+++ b/src/PreviewMailTransport.php
@@ -83,7 +83,7 @@ class PreviewMailTransport extends AbstractTransport
         $subject = $message->getOriginalMessage()->getSubject();
         $date = $message->getOriginalMessage()->getDate() ?? now();
 
-        return $this->storagePath() . '/' . Str::slug($date->format('u') . '_' . $to . $subject, '_');
+        return $this->storagePath() . '/' . Str::slug($date->format($this->filenameDateFormat()) . '_' . $to . $subject, '_');
     }
 
     protected function getMessageInfo(SentMessage $message): string
@@ -128,6 +128,11 @@ class PreviewMailTransport extends AbstractTransport
     protected function storagePath(): string
     {
         return config('mail-preview.storage_path');
+    }
+
+    protected function filenameDateFormat(): string
+    {
+        return config('mail-preview.filename_date_format') ?? 'u';
     }
 
     public function __toString(): string


### PR DESCRIPTION
This package is helpful not only if you want to open the mail preview immediately, but also to use a default mail driver locally (without preview links popup), keep the files for a day and open when needed. However, for this purpose, the default `u` (microseconds) date format is not very convenient (also, you can't sort by microseconds). 
When the files are kept for longer time, it's easier to sort them by date format like `Y-m-d_His`. This change would allow users to choose the format they want to.

E.g. 
<img width="274" alt="image" src="https://github.com/spatie/laravel-mail-preview/assets/12799259/4ec96d0b-86e7-43b4-a475-2eaa0ac1bd56">

vs
<img width="151" alt="image" src="https://github.com/spatie/laravel-mail-preview/assets/12799259/0832fe1e-496e-40df-a9d6-1d23a87a021b">

Also, it's backward compatible, even if users do not update their config file as I used `?? 'u'` - the old 'microseconds' format implementation.

Besides that, maybe a better default option would be to use `U` format, as the _timestamp_ is at least sortable:
```
u | Microseconds. Note that date() will always generate 000000 since it takes an int parameter, whereas DateTime::format() does support microseconds if DateTime was created with microseconds.
---
U | Seconds since the Unix Epoch (January 1 1970 00:00:00 GMT)
```
 